### PR TITLE
fix #293 retrieval of project and epic entities

### DIFF
--- a/src/lib/stories.ts
+++ b/src/lib/stories.ts
@@ -163,9 +163,17 @@ const hydrateStory: (entities: Entities, story: Story) => StoryHydrated = (
     return augmented;
 };
 
-const findEntity = <K, V>(entities: Map<K, V>, id: K) => {
+const isNumber = (val: string | number) => !!(val || val === 0) && !isNaN(Number(val.toString()));
+
+const findEntity = <_ , V>(entities: Map<string | number, V>, id: string | number) => {
+    // entities can be either a map of string ids or a map of number ids
+    // id, when passed in, is often a string coming from user input
+    // so we need to check both types to find the entity.
     if (entities.get(id)) {
         return entities.get(id);
+    }
+    if (isNumber(id) && Number(id.toString())) {
+        return entities.get((Number(id.toString())));
     }
     const match = new RegExp(`${id}`, 'i');
     return Object.values(entities).filter((s) => !!s.name.match(match))[0];


### PR DESCRIPTION
When user is creating a story and pass epic and project ids (instead of name),
shortcut-cli was not able to associate the project (or epic) with the given id.
The reason is that projects and epics are identified by numbers when user is giving
as input a string.
This fix implements a naive solution that is to locate for the project/epic by string
and then by number after a cast.