### PR TITLE
fix search with flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 ### Removed
 ### Fixed
+- Fix search with flags #291
 ### Security
 
 ---

--- a/src/lib/stories.ts
+++ b/src/lib/stories.ts
@@ -123,15 +123,17 @@ async function fetchStories(program: any, entities: Entities): Promise<Story[]> 
     }
 
     debug('filtering projects');
-    let regexProject = new RegExp(program.project, 'i');
-    const projectIds = Object.values(entities.projectsById).filter(
+    const regexProject = new RegExp(program.project, 'i');
+    const projectIds = [...entities.projectsById.values()].filter(
         (p) => !!(p.id + p.name).match(regexProject)
     );
 
     debug('request all stories for project(s)', projectIds.map((p) => p.name).join(', '));
     return Promise.all(
         projectIds.map((p) => client.listStories(p.id, null))
-    ).then((projectStories) => projectStories.reduce((acc, stories) => acc.concat(stories), []));
+    ).then((projectStories) =>
+        projectStories.reduce((acc, stories) => acc.concat(stories.data), [])
+    );
 }
 
 async function searchStories(program: any): Promise<Story[]> {


### PR DESCRIPTION
Regression introduced with switching over the shortcut client.
Fixes incorrect parsing of projects. Hence nothing was
displayed, with an exit code 0. Also fixes the issue where the
full response object was returned instead of `.data` which
contains the story. I think this whole story search based on
flags should be removed.

Fixes #291