### PR TITLE
fix story output with deleted comments

### DIFF
--- a/src/lib/stories.ts
+++ b/src/lib/stories.ts
@@ -438,7 +438,7 @@ const printDetailedStory = (story: StoryHydrated, entities: Entities = {}) => {
         );
         return c;
     });
-    story.comments.map((c) => {
+    story.comments.filter(comment => !comment.deleted).map((c) => {
         const author = entities.membersById.get(c.author_id);
         log(chalk.bold('Comment:') + `  ${formatLong(c.text)}`);
         log(`          ${author.profile.name} ` + chalk.bold('at:') + ` ${c.updated_at}`);


### PR DESCRIPTION
When printing the output of a story with deleted comments, the error
"Cannot read property 'split' of null" would be thrown due to the
deleted comment text being null.

This fix filters out deleted comments from the display
fixes #297 