### PR TITLE
Support Team in Short Create

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ Comment: This is a commend
     -o, --owners [id|name]    Set owners of story, comma-separated
     -O, --open                Open story in browser
     -p, --project [id|name]   Set project of story, required
+    -T, --team [id|name]      Set team of story
     -t, --title [text]        Set title of story, required
     -s, --state [id|name]     Set workflow state of story
     -y, --type [name]         Set type of story, default: feature

--- a/src/bin/short-create.ts
+++ b/src/bin/short-create.ts
@@ -8,6 +8,7 @@ import client from '../lib/client';
 import {
     CreateStoryParams,
     Epic,
+    Group,
     Iteration,
     Project,
     Story,
@@ -41,6 +42,7 @@ const program = commander
     .option('-o, --owners [id|name]', 'Set owners of story, comma-separated', '')
     .option('-O, --open', 'Open story in browser')
     .option('-p, --project [id|name]', 'Set project of story, required', '')
+    .option('-T, --team [id|name]', 'Set team of story', '')
     .option('-t, --title [text]', 'Set title of story, required', '')
     .option('-s, --state [id|name]', 'Set workflow state of story', '')
     .option('-y, --type [name]', 'Set type of story, default: feature', 'feature')
@@ -57,6 +59,9 @@ const main = async () => {
     } as CreateStoryParams;
     if (program.project) {
         update.project_id = (storyLib.findProject(entities, program.project) || ({} as Project)).id;
+    }
+    if (program.team) {
+        update.group_id = (storyLib.findGroup(entities, program.team) || ({} as Group)).id;
     }
     if (program.state) {
         update.workflow_state_id = (

--- a/src/lib/stories.ts
+++ b/src/lib/stories.ts
@@ -184,6 +184,9 @@ const findEntity = <_, V>(entities: Map<string | number, V>, id: string | number
 const findProject = (entities: Entities, project: number) =>
     findEntity(entities.projectsById, project);
 
+const findGroup = (entities: Entities, group: number) =>
+    findEntity(entities.groupsById, group);
+
 const findState = (entities: Entities, state: number) => findEntity(entities.statesById, state);
 
 const findEpic = (entities: Entities, epicName: number) => findEntity(entities.epicsById, epicName);
@@ -405,6 +408,9 @@ const printDetailedStory = (story: StoryHydrated, entities: Entities = {}) => {
     if (story.project) {
         log(chalk.bold('Project:') + chalk.bold(`   #${story.project_id} `) + story.project.name);
     }
+    if (story.group) {
+        log(chalk.bold('Team:') + chalk.bold(`   #${story.group_id} `) + story.group.name);
+    }
     if (story.epic) {
         log(chalk.bold('Epic:') + chalk.bold(`      #${story.epic_id} `) + story.epic.name);
     } else {
@@ -518,6 +524,7 @@ export default {
     fetchEntities,
     hydrateStory,
     findProject,
+    findGroup,
     findState,
     findEpic,
     findIteration,


### PR DESCRIPTION
Currently you cannot set the Team when creating a Shortcut Story. This adds a new flag `-T, --team`. 