### PR TITLE
Don't require --project on story creation if --state is set

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,10 +236,10 @@ Comment: This is a commend
     -l, --label [id|name]     Stories with label id/name, by regex
     -o, --owners [id|name]    Set owners of story, comma-separated
     -O, --open                Open story in browser
-    -p, --project [id|name]   Set project of story, required
+    -p, --project [id|name]   Set project of story, required if --state is not set
     -T, --team [id|name]      Set team of story
     -t, --title [text]        Set title of story, required
-    -s, --state [id|name]     Set workflow state of story
+    -s, --state [id|name]     Set workflow state of story, required if --project is not set
     -y, --type [name]         Set type of story, default: feature
     -h, --help                output usage information
     --git-branch              Checkout git branch from story slug <mention-name>/ch<id>/<type>-<title>

--- a/src/bin/short-create.ts
+++ b/src/bin/short-create.ts
@@ -41,10 +41,10 @@ const program = commander
     .option('-l, --label [id|name]', 'Stories with label id/name, by regex', '')
     .option('-o, --owners [id|name]', 'Set owners of story, comma-separated', '')
     .option('-O, --open', 'Open story in browser')
-    .option('-p, --project [id|name]', 'Set project of story, required', '')
+    .option('-p, --project [id|name]', 'Set project of story, required if --state is not set', '')
     .option('-T, --team [id|name]', 'Set team of story', '')
     .option('-t, --title [text]', 'Set title of story, required', '')
-    .option('-s, --state [id|name]', 'Set workflow state of story', '')
+    .option('-s, --state [id|name]', 'Set workflow state of story, required if --project is not set', '')
     .option('-y, --type [name]', 'Set type of story, default: feature', 'feature')
     .parse(process.argv);
 
@@ -86,9 +86,13 @@ const main = async () => {
         update.labels = storyLib.findLabelNames(entities, program.label);
     }
     let story: Story;
-    if (!update.name || !update.project_id) {
+    if (!update.name) {
         if (!program.idonly) spin.stop(true);
-        log('Must provide --title and --project');
+        log('Must provide --title');
+    }
+    else if (!update.project_id && !update.workflow_state_id) {
+        if (!program.idonly) spin.stop(true);
+        log('Must provide --project or --state');
     } else {
         try {
             story = await client.createStory(update).then((r) => r.data);


### PR DESCRIPTION
This branch attempts to address #305 , by accounting for the API requiring that either `project_id` or `workflow_state_id` be passed when calling `create`. API documentation does not actually reflect this, but the error response does:

```bash
zsh/3 10102 [130]  (git)-[305_project_not_required]-% curl -X POST \                                                  
  -H "Content-Type: application/json" \
  -H "Shortcut-Token: $SHORTCUT_API_TOKEN" \
  -d \
  '{ "epic_id": [redacted], "name": "test story", "story_type": "bug" }' \
  -L "https://api.app.shortcut.com/api/v3/stories" -v
Note: Unnecessary use of -X or --request, POST is already inferred.
* Host api.app.shortcut.com:443 was resolved.
[redacted]
> POST /api/v3/stories HTTP/2
> Host: api.app.shortcut.com
> User-Agent: curl/8.6.0
> Accept: */*
> Content-Type: application/json
> Shortcut-Token: [redacted]
> Content-Length: 63
> 
< HTTP/2 422 
< date: Fri, 24 May 2024 16:08:46 GMT
< content-type: application/json;charset=utf-8
< [redacted]
< 
* Connection #0 to host api.app.shortcut.com left intact
{"message":"Must provide at least one of Workflow or Project."}%
```

Changes:
- updates help dialog for `create`
- updates README for `create`
- sets an `else if` to check if both `--state` and `--project` are not provided, then throw an error.